### PR TITLE
Add virtual task node handling to graph initialization

### DIFF
--- a/GDesigner/gnn/node_encoder.py
+++ b/GDesigner/gnn/node_encoder.py
@@ -1,0 +1,49 @@
+from typing import Callable, Optional, Union
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+
+class NodeEncoder(nn.Module):
+    """Lightweight encoder that maps a textual query to a node embedding."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: Optional[int] = None,
+        activation: Optional[nn.Module] = None,
+        embedding_fn: Optional[Callable[[Union[str, np.ndarray]], np.ndarray]] = None,
+    ):
+        super().__init__()
+        self.input_dim = input_dim
+        self.output_dim = output_dim if output_dim is not None else input_dim
+        self.embedding_fn = embedding_fn
+        self.projection = nn.Linear(self.input_dim, self.output_dim)
+        self.activation = activation if activation is not None else nn.ReLU()
+
+    def forward(self, query_embedding: torch.Tensor) -> torch.Tensor:
+        """Encode a pre-computed query embedding."""
+
+        if query_embedding.dim() == 1:
+            query_embedding = query_embedding.unsqueeze(0)
+            squeeze_back = True
+        else:
+            squeeze_back = False
+
+        encoded = self.projection(query_embedding)
+        encoded = self.activation(encoded)
+
+        if squeeze_back:
+            encoded = encoded.squeeze(0)
+        return encoded
+
+    def encode(self, query: str) -> torch.Tensor:
+        if self.embedding_fn is None:
+            raise ValueError("embedding_fn is not provided; cannot encode from raw text.")
+        embedding = self.embedding_fn(query)
+        if isinstance(embedding, np.ndarray):
+            tensor = torch.tensor(embedding, dtype=torch.float32)
+        else:
+            tensor = torch.as_tensor(embedding, dtype=torch.float32)
+        return self.forward(tensor)

--- a/GDesigner/graph/__init__.py
+++ b/GDesigner/graph/__init__.py
@@ -1,5 +1,8 @@
-from GDesigner.graph.node import Node
+from GDesigner.graph.node import Node, TaskNode
 from GDesigner.graph.graph import Graph
 
-__all__ = ["Node",
-           "Graph",]
+__all__ = [
+    "Node",
+    "TaskNode",
+    "Graph",
+]

--- a/GDesigner/prompt/prompt_set.py
+++ b/GDesigner/prompt/prompt_set.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Dict, Any, List, Tuple
 from abc import ABC, abstractmethod
 
 
@@ -89,3 +89,6 @@ class PromptSet(ABC):
     @abstractmethod
     def get_decision_few_shot() ->str:
         """ TODO """
+
+    def get_anchor_topology(self) -> List[Tuple[str, str]]:
+        return self.get_role_connection()


### PR DESCRIPTION
## Summary
- add a lightweight TaskNode placeholder and register it alongside agent nodes during graph setup, expanding mask generation to cover task edges
- update feature and adjacency construction to include the virtual task node, introducing a reusable NodeEncoder for query embeddings and storing the anchor adjacency matrix
- expose anchor-topology retrieval through the prompt set base class for downstream regularization

## Testing
- python -m compileall GDesigner/graph GDesigner/prompt GDesigner/gnn

------
https://chatgpt.com/codex/tasks/task_e_68d8cd1e12e0832d8eb1c7d7f8886354